### PR TITLE
New Notification functionality

### DIFF
--- a/lib/backend/services/notification_services.dart
+++ b/lib/backend/services/notification_services.dart
@@ -12,17 +12,19 @@ class NotificationServices {
           'title': doc['title'],
           'description': doc['description'],
           'time': doc['time'].toDate(),
+          'requires_action': doc['requires_action'],
         };
       }).toList();
 
       return notifications;
   }
 
-  Future<void> addNotification(String title, String description, DateTime time) async {
+  Future<void> addNotification(String title, String description, DateTime time, bool requiresAction) async {
       await firestore.collection('NOTIFICATION').add({
         'title': title,
         'description': description,
         'time': Timestamp.fromDate(time),
+        'requires_action': requiresAction,
       });
   }
 }

--- a/lib/frontend/pages/notification_details.dart
+++ b/lib/frontend/pages/notification_details.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:volunteerexpress/frontend/themes/colors.dart';
+
+class NotificationDetailPage extends StatelessWidget {
+  final String title;
+  final String description;
+  final DateTime dateTime;
+  final bool requiresAction;
+
+  const NotificationDetailPage({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.dateTime, 
+    required this.requiresAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Notification Details'),
+        backgroundColor: primaryAccentColor,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '${dateTime.month}-${dateTime.day}-${dateTime.year} at ${dateTime.hour % 12 == 0 ? 12 : dateTime.hour % 12}:${dateTime.minute.toString().padLeft(2, '0')} ${dateTime.hour >= 12 ? 'PM' : 'AM'}',
+              style: const TextStyle(fontSize: 14, color: Colors.grey),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              description,
+              style: const TextStyle(fontSize: 16),
+            ),
+            const SizedBox(height: 20),
+            if (requiresAction) actionButtons(),
+          ],
+        ),
+      ),
+    );
+  }
+  Widget actionButtons() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        ElevatedButton(
+          onPressed: () {
+            // Handle accept action
+          },
+          style: ElevatedButton.styleFrom(backgroundColor: Colors.green),
+          child: const Text("Accept"),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            // Handle reject action
+          },
+          style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+          child: const Text("Reject"),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/frontend/pages/notifications.dart
+++ b/lib/frontend/pages/notifications.dart
@@ -5,6 +5,7 @@ import 'package:volunteerexpress/frontend/constants/routes.dart';
 import 'package:volunteerexpress/frontend/enums/menu_action_enums.dart';
 import 'package:volunteerexpress/frontend/themes/colors.dart';
 import 'package:volunteerexpress/backend/services/notification_services.dart';
+import 'package:volunteerexpress/backend/services/notification_services.dart';
 
 class NotificationViewPage extends StatefulWidget {
   const NotificationViewPage({super.key});
@@ -169,6 +170,29 @@ class _NotificationViewPageState extends State<NotificationViewPage> {
               fontSize: 10,
             ),
           )
+          TextButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => NotificationDetailPage(
+                    title: notifications[index]['title'],
+                    description: notifications[index]['description'],
+                    dateTime: notifications[index]['time'],
+                    requiresAction: notifications[index]['requires_action']
+                  ),
+                ),
+              );
+            },
+            child: const Text(
+              'Open',
+              style: TextStyle(
+                color: primaryAccentColor,
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/test/notification_services_test.dart
+++ b/test/notification_services_test.dart
@@ -18,11 +18,13 @@ void main() {
         'title': 'Event Tomorrow',
         'description': 'Event at 2PM tomorrow.',
         'time': Timestamp.fromDate(DateTime.now().subtract(const Duration(hours: 1))),
+        'requires_action': false,
       });
       await fakeFirestore.collection('NOTIFICATION').add({
         'title': 'New Event Available',
         'description': 'New Event available now!',
         'time': Timestamp.fromDate(DateTime.now().subtract(const Duration(days: 1))),
+        'requires_action': true,
       });
 
       final result = await notificationService.fetchNotifications();
@@ -31,6 +33,7 @@ void main() {
       expect(result.length, 2);
       expect(result[0]['title'], 'Event Tomorrow');
       expect(result[1]['description'], 'New Event available now!');
+      expect(result[1]['requires_action'], true);
     });
 
     test('should return an empty list when no notifications are available', () async {
@@ -46,6 +49,7 @@ void main() {
         'New Event',
         'A new event has been added',
         now,
+        false,
       );
 
       final snapshot = await fakeFirestore.collection('NOTIFICATION').get();
@@ -55,6 +59,7 @@ void main() {
       expect(notifications[0]['title'], 'New Event');
       expect(notifications[0]['description'], 'A new event has been added');
       expect((notifications[0]['time'] as Timestamp).toDate(), now);
+      expect(notifications[0]['requires_action'], false);
     });
   });
 }


### PR DESCRIPTION
Added new field to NOTIFICATION collection in Firebase: a boolean called requires_action. If true, when pressing new button "open" should display the previously available information plus two new buttons "Accept" & "Reject". If false, no buttons should appear. Also updated unit tests.